### PR TITLE
Implement TestAccessNestedMap.test_access_nested_map_exception

### DIFF
--- a/0x03-Unittests_and_integration_tests/test_utils.py
+++ b/0x03-Unittests_and_integration_tests/test_utils.py
@@ -12,7 +12,19 @@ class TestAccessNestedMap(unittest.TestCase):
         ({"a": {"b": 2}}, ("a", "b"), 2),
     ])
     def test_access_nested_map(self, nested_map, path, expected_result):
+        """
+        Test access_nested_map function for retrieving values.
+        """
         self.assertEqual(access_nested_map(nested_map, path), expected_result)
+
+    def test_access_nested_map_exception(self, nested_map, path,
+                                         expected_exception, expected_message):
+        """
+        Test access_nested_map function for raising exceptions.
+        """
+        with self.assertRaises(expected_exception) as context:
+            access_nested_map(nested_map, path)
+        self.assertEqual(str(context.exception), expected_message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement TestAccessNestedMap.test_access_nested_map_exception. 
Use the assertRaises context manager to test that a KeyError is raised for the  inputs 
(use @parameterized.expand):