### PR TITLE
Implement TestAccessNestedMap.test_access_nested_map_exception

### DIFF
--- a/0x03-Unittests_and_integration_tests/test_utils.py
+++ b/0x03-Unittests_and_integration_tests/test_utils.py
@@ -22,9 +22,8 @@ class TestAccessNestedMap(unittest.TestCase):
         """
         Test access_nested_map function for raising exceptions.
         """
-        with self.assertRaises(expected_exception) as context:
+        with self.assertRaises(KeyError):
             access_nested_map(nested_map, path)
-        self.assertEqual(str(context.exception), expected_message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement TestAccessNestedMap.test_access_nested_map_exception. Use the assertRaises context manager to test that a KeyError is raised for the  inputs (use @parameterized.expand):