### PR TITLE
Mock HTTP calls

### DIFF
--- a/0x03-Unittests_and_integration_tests/test_utils.py
+++ b/0x03-Unittests_and_integration_tests/test_utils.py
@@ -16,7 +16,7 @@ class TestAccessNestedMap(unittest.TestCase):
         """
         Test access_nested_map function for retrieving values.
         """
-        self.assertEqual(access_nested_map(nested_map, path), expected_result)
+        self.assertEqual(expected, access_nested_map(nested_map, path))
 
     def test_access_nested_map_exception(self, nested_map: Dict, path:
                                          Tuple[str]) -> None:
@@ -27,5 +27,24 @@ class TestAccessNestedMap(unittest.TestCase):
             access_nested_map(nested_map, path)
 
 
-if __name__ == '__main__':
-    unittest.main()
+class TestGetJson(unittest.TestCase):
+    """Defines tests for get_json utility"""
+
+    @parameterized.expand([
+        ("http://example.com", {"payload": True}),
+        ("http://holberton.io", {"payload": False}),
+    ])
+    def test_get_json(self, test_url: str, test_payload:
+                      Dict[str, bool]) -> None:
+        """
+        Test that it returns a valid json payload
+        Args:
+            test_url (str): url to make a request to
+            test_payload (Dict): expected payload from the response
+        Returns:
+            None
+        """
+        config = {'return_value.json.return_value': test_payload}
+        with patch('requests.get', autospec=True, **config) as mockRequestGet:
+            self.assertEqual(get_json(test_url), test_payload)
+            mockRequestGet.assert_called_once_with(test_url)


### PR DESCRIPTION
Define the TestGetJson(unittest.TestCase) class and implement the TestGetJson.test_get_json method to test that utils.get_json returns the expected result.