### PR TITLE
Unittests and Integration Tests

### DIFF
--- a/0x03-Unittests_and_integration_tests/test_utils.py
+++ b/0x03-Unittests_and_integration_tests/test_utils.py
@@ -48,3 +48,29 @@ class TestGetJson(unittest.TestCase):
         with patch('requests.get', autospec=True, **config) as mockRequestGet:
             self.assertEqual(get_json(test_url), test_payload)
             mockRequestGet.assert_called_once_with(test_url)
+
+
+class TestMemoize(unittest.TestCase):
+    """
+    Defines test for memoize utility function
+    """
+    def test_memoize(self) -> None:
+        """
+        Test memoize function
+        """
+        class TestClass:
+            """
+            Test class
+            """
+            def a_method(self):
+                return 42
+
+            @memoize
+            def a_property(self):
+                return self.a_method()
+
+        with patch.object(TestClass, 'a_method') as mockMethod:
+            test = TestClass()
+            self.assertEqual(test.a_property, mockMethod.return_value)
+            self.assertEqual(test.a_property, mockMethod.return_value)
+            mockMethod.assert_called_once()


### PR DESCRIPTION
Use @patch as a decorator to make sure get_json is called once with the expected argument but make sure it is not executed.

Use patch as a context manager to patch GithubOrgClient.org and make it return a known payload.
Test that the result of _public_repos_url is the expected one based on the mocked payload.

Use @patch as a decorator to mock get_json and make it return a payload of your choice.
Use patch as a context manager to mock GithubOrgClient._public_repos_url and return a choice value.

Implement TestGithubOrgClient.test_has_license to unit-test GithubOrgClient.has_license.

Use @patch as a decorator to mock get_json and make it return a payload of your choice.
Use patch as a context manager to mock GithubOrgClient._public_repos_url and return a value of your choice.
